### PR TITLE
Fix placeholder handling in getMessage

### DIFF
--- a/src/main/java/fr/P2W/wplmanager/WorldPluginManager.java
+++ b/src/main/java/fr/P2W/wplmanager/WorldPluginManager.java
@@ -77,8 +77,10 @@ public class WorldPluginManager extends JavaPlugin implements Listener {
 
     public String getMessage(String key, Map<String, String> placeholders) {
         String message = messagesConfig.getString(key, key);
-        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
-            message = message.replace("{" + entry.getKey() + "}", entry.getValue());
+        if (placeholders != null) {
+            for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+                message = message.replace("{" + entry.getKey() + "}", entry.getValue());
+            }
         }
         return ChatColor.translateAlternateColorCodes('&', message);
     }


### PR DESCRIPTION
## Summary
- avoid `NullPointerException` when retrieving messages without placeholders

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f694167c8328a6f6559d966d4f5b