### PR TITLE
Add ProtocolLib packet blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ WorldPluginManager is a Minecraft plugin that allows server administrators to ma
 - View the status of plugins in different worlds.
 - Customizable messages through `messages.yml` with support for placeholders.
 - Permission-based command execution.
+- Blocks plugin channel packets using ProtocolLib when a plugin is disabled in a world.
 
 ## Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,12 @@
             <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/fr/P2W/wplmanager/WorldPluginManager.java
+++ b/src/main/java/fr/P2W/wplmanager/WorldPluginManager.java
@@ -4,6 +4,13 @@ import fr.P2W.wplmanager.commands.DisplCommand;
 import fr.P2W.wplmanager.commands.EnplCommand;
 import fr.P2W.wplmanager.commands.FlagsCommand;
 import fr.P2W.wplmanager.commands.FocusCommand;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketType;
+import com.comphenix.protocol.wrappers.MinecraftKey;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
@@ -28,6 +35,7 @@ public class WorldPluginManager extends JavaPlugin implements Listener {
     private Map<String, Map<String, Boolean>> pluginWorldStatus = new HashMap<>();
     private final String PLUGIN_NAME = "WorldPluginManager";
     private FileConfiguration messagesConfig;
+    private ProtocolManager protocolManager;
 
     private static final List<String> WORLD_EDIT_COMMANDS = Arrays.asList(
         "help", "tool", "sel", "desel", "pos1", "pos2", "hpos1", "hpos2", "chunk",
@@ -58,6 +66,7 @@ public class WorldPluginManager extends JavaPlugin implements Listener {
         getCommand("focus").setTabCompleter(new FocusCommand(this));
         loadConfig();
         getServer().getPluginManager().registerEvents(this, this);
+        registerPacketListeners();
         getLogger().info("Plugin enabled!");
     }
 
@@ -232,5 +241,43 @@ public class WorldPluginManager extends JavaPlugin implements Listener {
             setPluginStatus(pluginName, world, world.equals(worldName), sender);
         }
         saveConfigData();
+    }
+
+    private void registerPacketListeners() {
+        if (Bukkit.getPluginManager().getPlugin("ProtocolLib") == null) {
+            getLogger().warning("ProtocolLib not found. Packet listeners disabled.");
+            return;
+        }
+
+        protocolManager = ProtocolLibrary.getProtocolManager();
+        protocolManager.addPacketListener(new PacketAdapter(this, ListenerPriority.NORMAL,
+                PacketType.Play.Client.CUSTOM_PAYLOAD, PacketType.Play.Server.CUSTOM_PAYLOAD) {
+
+            @Override
+            public void onPacketReceiving(PacketEvent event) {
+                if (shouldCancelPacket(event.getPlayer(), event.getPacket().getMinecraftKeys().read(0))) {
+                    event.setCancelled(true);
+                }
+            }
+
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                if (shouldCancelPacket(event.getPlayer(), event.getPacket().getMinecraftKeys().read(0))) {
+                    event.setCancelled(true);
+                }
+            }
+        });
+    }
+
+    private boolean shouldCancelPacket(Player player, MinecraftKey channel) {
+        String key = channel.getFullKey();
+        String pluginNamePart = key.contains(":" ) ? key.substring(0, key.indexOf(":")) : key;
+        Plugin target = Bukkit.getPluginManager().getPlugin(pluginNamePart);
+        if (target == null) {
+            return false;
+        }
+        String pluginId = target.getDescription().getName();
+        String worldName = player.getWorld().getName();
+        return !isPluginEnabledInWorld(pluginId, worldName);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: WorldPluginManager
 main: fr.P2W.wplmanager.WorldPluginManager
 version: 2.0
+softdepend: [ProtocolLib]
 commands:
   displ:
     description: Disables a plugin in a specified world.


### PR DESCRIPTION
## Summary
- depend on ProtocolLib
- block plugin message packets for disabled plugins using ProtocolLib
- note the new feature in README
- list ProtocolLib as soft dependency

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6d99d3c83288446d912d86b6a82